### PR TITLE
Adjust manifest, webpack, and launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Direct Debugging",
+      "type": "node",
+      "request": "attach",
+      "port": 9223,
+      "timeout": 600000,
+      "trace": true
+    },
+    {
       "name": "Outlook Desktop (Edge Chromium)",
       "type": "msedge",
       "request": "attach",

--- a/appPackage/manifest.json
+++ b/appPackage/manifest.json
@@ -153,7 +153,6 @@
                             "builtInTabId": "TabDefault",
                             "groups": [
                                 {
-                                    "overriddenByRibbonApi": false,
                                     "id": "CategoriesGroupMessageCompose",
                                     "label": "Office Add-ins Smart Alerts Sample",
                                     "controls": [
@@ -164,15 +163,15 @@
                                             "icons": [
                                                 {
                                                     "size": 16,
-                                                    "file": "icon-16.png"
+                                                    "file": "https://localhost:3000/assets/icon-16.png"
                                                 },
                                                 {
                                                     "size": 32,
-                                                    "file": "icon-32.png"
+                                                    "file": "https://localhost:3000/assets/icon-32.png"
                                                 },
                                                 {
                                                     "size": 80,
-                                                    "file": "icon-80.png"
+                                                    "file": "https://localhost:3000/assets/icon-80.png"
                                                 }
                                             ],
                                             "supertip": {
@@ -212,7 +211,6 @@
                             "builtInTabId": "TabDefault",
                             "groups": [
                                 {
-                                    "overriddenByRibbonApi": false,
                                     "id": "CategoriesGroupAppointmentOrganizer",
                                     "label": "Office Add-ins Smart Alerts Sample",
                                     "controls": [
@@ -223,15 +221,15 @@
                                             "icons": [
                                                 {
                                                     "size": 16,
-                                                    "file": "icon-16_02.png"
+                                                    "file": "https://localhost:3000/assets/icon-16_02.png"
                                                 },
                                                 {
                                                     "size": 32,
-                                                    "file": "icon-32_02.png"
+                                                    "file": "https://localhost:3000/assets/icon-32_02.png"
                                                 },
                                                 {
                                                     "size": 80,
-                                                    "file": "icon-80_02.png"
+                                                    "file": "https://localhost:3000/assets/icon-80_02.png"
                                                 }
                                             ],
                                             "supertip": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,6 @@ module.exports = async (env, options) => {
     entry: {
       polyfill: ["core-js/stable", "regenerator-runtime/runtime"],
       taskpane: ["./src/taskpane/taskpane.js", "./src/taskpane/taskpane.html"],
-      commands: "./src/commands/commands.js",
     },
     output: {
       clean: true,
@@ -62,6 +61,10 @@ module.exports = async (env, options) => {
       new CopyWebpackPlugin({
         patterns: [
           {
+            from: "./src/commands/commands.js",
+            to: "commands.js",
+          },
+          {
             from: "appPackage/assets/*",
             to: "assets/[name][ext][query]",
           },
@@ -81,7 +84,6 @@ module.exports = async (env, options) => {
       new HtmlWebpackPlugin({
         filename: "commands.html",
         template: "./src/commands/commands.html",
-        chunks: ["polyfill", "commands"],
       }),
     ],
     devServer: {


### PR DESCRIPTION
Update webpack to just copy the event file instead of augmenting it.
Update the manifest to match the schema reference.
Add the debug config for attaching to the event runtime (need to use the bundle to get the breakpoints to work).